### PR TITLE
make icon_font optional via config option "button_icon"

### DIFF
--- a/src/share.coffee
+++ b/src/share.coffee
@@ -25,7 +25,7 @@ class Share extends ShareUtils
         flyout: 'top center'
         button_text: 'Share'
         button_font: true
-        button_icon: true
+        icon_font: true
 
       networks:
         google_plus:
@@ -71,7 +71,7 @@ class Share extends ShareUtils
     @normalize_network_configuration()
 
     ## Inject Icon Fontset
-    @inject_icons() if @config.ui.button_icon
+    @inject_icons() if @config.ui.icon_font
 
     ## Inject Google's Lato Fontset (if enabled)
     @inject_fonts() if @config.ui.button_font


### PR DESCRIPTION
I already have an icon font therefor I dont want to make the extra http request for the default icons. This commit introduces a new config option "button_icon" that is set to true by default and (if false) would skip the css_injection of you icon font
