### PR TITLE
Avoid dummy pop-up in Email share

### DIFF
--- a/src/share.coffee
+++ b/src/share.coffee
@@ -185,7 +185,9 @@ class Share extends ShareUtils
     @popup('https://www.pinterest.com/pin/create/button', url: @config.networks.pinterest.url, media: @config.networks.pinterest.image, description: @config.networks.pinterest.description)
 
   network_email: ->
-    @popup('mailto:', subject: @config.networks.email.title, body: @config.networks.email.description)
+    #@popup('mailto:', subject: @config.networks.email.title, body: @config.networks.email.description)
+    window.location.href = 'mailto: ?subject=' + this.config.networks.email.title + '&body=' + this.config.networks.email.description;
+    return false;
 
 
   #############


### PR DESCRIPTION
This fix will avoid dummy pop-up when email share is used.
It will directly open up the email client compose window. (In my case outlook).
