### PR TITLE
Reworks unused display var to set visibility class

### DIFF
--- a/src/share-button.js
+++ b/src/share-button.js
@@ -729,7 +729,8 @@ class ShareButton extends ShareUtils {
   _detectNetworks() {
     // Update network-specific configuration with global configurations
     for (let network of Object.keys(this.config.networks)) {
-      let display;
+      let displayClass = 'disabled';
+
       for (let option of Object.keys(this.config.networks[network])) {
         if (this.config.networks[network][option] === null) {
           this.config.networks[network][option] = this.config[option];
@@ -738,13 +739,11 @@ class ShareButton extends ShareUtils {
 
       // Check for enabled networks and display them
       if (this.config.networks[network].enabled) {
-        this.class = 'enabled';
+        displayClass = 'enabled';
         this.config.enabledNetworks += 1;
       }
-      else
-        this.class = 'disabled';
 
-      this.config.networks[network].class = this.class;
+      this.config.networks[network].class = displayClass;
     }
   }
 


### PR DESCRIPTION
replaces this.class instance variable as it looks like it is not used anywhere else