### PR TITLE
Only distribute the dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
   ],
   "engines": {},
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE",
+    "docs"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "share",
     "social"
   ],
-  "engines": {}
+  "engines": {},
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
This only distributes the "dist" folder on npm installs. This reduces the package size when installing.
