### PR TITLE
Set default height and width for SVGs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ gulp.task('style', function() {
       use: [
         autoprefixer(),
         axis(),
-        poststylus([postcssSVG({ paths: ['./src/svg' ]})])
+        poststylus([postcssSVG({ paths: ['./src/svg' ], defaults: "[height]:100%; [width]:100%;" })])
       ]
     }))
     .pipe(gulp.dest('dist/'))


### PR DESCRIPTION
This resolves #305 (chrome incompatibility) by setting a default height and width for SVGs at build time.
